### PR TITLE
Update vm.VM object after updating network configuration

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -863,7 +863,7 @@ func getPrimaryNetwork(vm *types.Vm) *types.NetworkConnection {
 func (r *VCDMachineReconciler) reconcileVMNetworks(vdcManager *vcdsdk.VdcManager, vApp *govcd.VApp, vm *govcd.VM, networks []string) error {
 	connections, err := vm.GetNetworkConnectionSection()
 	if err != nil {
-		return errors.Errorf("Failed to get attached networks to VM")
+		return errors.Wrapf(err, "Failed to get attached networks to VM")
 	}
 
 	desiredConnectionArray := make([]*types.NetworkConnection, len(networks))
@@ -871,7 +871,7 @@ func (r *VCDMachineReconciler) reconcileVMNetworks(vdcManager *vcdsdk.VdcManager
 	for index, ovdcNetwork := range networks {
 		err = ensureNetworkIsAttachedToVApp(vdcManager, vApp, ovdcNetwork)
 		if err != nil {
-			return errors.Errorf("Error ensuring network [%s] is attached to vApp", ovdcNetwork)
+			return errors.Wrapf(err, "Error ensuring network [%s] is attached to vApp", ovdcNetwork)
 		}
 
 		desiredConnectionArray[index] = getNetworkConnection(connections, ovdcNetwork)
@@ -887,8 +887,10 @@ func (r *VCDMachineReconciler) reconcileVMNetworks(vdcManager *vcdsdk.VdcManager
 
 		err = vm.UpdateNetworkConnectionSection(connections)
 		if err != nil {
-			return errors.Errorf("failed to update networks of VM")
+			return errors.Wrapf(err, "failed to update networks of VM")
 		}
+		// update vm.VM object for the rest of the flow, especially for getPrimaryNetwork function
+		vm.VM.NetworkConnectionSection = connections
 	}
 
 	return nil


### PR DESCRIPTION
Upstream PR: https://github.com/vmware/cluster-api-provider-cloud-director/pull/368

When we call vm.UpdateNetworkConnectionSection method, we update network interfaces of the VM. Then we call getPrimaryNetwork function but it uses old vm object. We need to update vm object after updating network configuration for consistency.

## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
