### PR TITLE
Add CircleCI config to build&push container images automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,12 @@
-
-
 version: 2.1
 
-orbs:
-  architect: giantswarm/architect@4.27.0
-
-workflows:
+jobs:
   build:
-    jobs:
-      - architect/go-build:
-          context: architect
-          name: go-build
-          binary: cluster-api-provider-cloud-director
-          resource_class: xlarge
-          filters:
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: architect
-          name: push-cluster-api-provider-cloud-director-to-quay
-          image: "quay.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          requires:
-            - go-build
-
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-deletion-blocker-operator-to-docker
-          image: "docker.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.17
+    steps:
+      - checkout
+      - run:
+          name: Build binary
+          command: make build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+
+
+version: 2.1
+
+orbs:
+  architect: giantswarm/architect@4.27.0
+
+workflows:
+  build:
+    jobs:
+      - architect/go-build:
+          context: architect
+          name: go-build
+          binary: cluster-api-provider-cloud-director
+          resource_class: xlarge
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-docker:
+          context: architect
+          name: push-cluster-api-provider-cloud-director-to-quay
+          image: "quay.io/giantswarm/cluster-api-provider-cloud-director-vcd"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          requires:
+            - go-build
+
+      - architect/push-to-docker:
+          context: "architect"
+          name: push-deletion-blocker-operator-to-docker
+          image: "docker.io/giantswarm/cluster-api-provider-cloud-director-vcd"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+          requires:
+            - go-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,46 @@
+# We are supposed to use architect-orb to build&push container images.
+# However, architect-orb has strict rules and tests. We don't have full control over this repository.
+# That is why we introduced this custom configuration in this repository.
+# Keep this file as it is while merging changes from upstream repository.
+
 version: 2.1
 
 jobs:
   build:
-    working_directory: ~/repo
-    docker:
-      - image: cimg/go:1.17
+    machine:
+      image: ubuntu-2204:2022.04.2
     steps:
       - checkout
       - run:
-          name: Build binary
-          command: make build
+          name : Build container
+          command: |
+            export IMG=capvcd:latest
+            make docker-build
+           
+      - run:
+          name: Push to quay.io
+          command: |
+            echo "$QUAY_PASSWORD" | docker login quay.io --username $QUAY_USERNAME --password-stdin
+            
+            IMG_TAG=$(git rev-parse --short HEAD)
+            docker tag capvcd:latest quay.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG
+            docker push quay.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG
+
+            echo "Pushed to quay.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG"
+
+      - run:
+          name: Push to docker.io
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+
+            IMG_TAG=$(git rev-parse --short HEAD)
+            docker tag capvcd:latest docker.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG
+            docker push docker.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG
+
+            echo "Pushed to docker.io/giantswarm/cluster-api-provider-cloud-director-vcd:$IMG_TAG"
+workflows:
+  build-workflow:
+    jobs:
+      - build:
+          context:
+            - architect


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24991

We are supposed to use architect-orb to build&push container images.
However, architect-orb has strict rules and tests. We don't have full control over this repository.
That is why we introduced a custom config for image building.

> CAPA has its own custom CircleCI config too. See https://github.com/giantswarm/cluster-api-provider-aws/blob/main/.circleci/config.yml