### PR TITLE
Add support for Flatcar

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -758,6 +758,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	// Convert netmask to CIDR notation for ignition
 	netmask := net.ParseIP(OrgVdcNetwork.Configuration.IpScopes.IpScope.Netmask)
 	netmaskCidr, _ := net.IPMask(ip.To4()).Size()
+	ignitionAddress := fmt.Sprint(machineAddress) + "/" + fmt.Sprint(netmaskCidr)
 
 	if vmStatus != "POWERED_ON" {
 		// try to power on the VM
@@ -768,9 +769,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.ignition.config.data":          b64CloudInitScript,
 			"guestinfo.ignition.config.data.encoding": "base64",
 			"guestinfo.ignition.vmname": vmName,
-			"guestinfo.ignition.machineaddress": machineAddress,
+			"guestinfo.ignition.machineaddress": ignitionAddress,
 			"guestinfo.ignition.gateway": OrgVdcNetwork.Configuration.IpScopes.IpScope.Gateway,
-			"guestinfo.ignition.netmask": netmaskCidr,
 			"guestinfo.ignition.dns1": OrgVdcNetwork.Configuration.IpScopes.IpScope.Dns1,
 			"guestinfo.ignition.dns2": OrgVdcNetwork.Configuration.IpScopes.IpScope.Dns2,
 			"disk.enableUUID":             "1",

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -525,7 +525,10 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 		bootstrapData = string(mergedCloudInitBytes)
 	} else if bootstrapFormat == BootstrapFormatIgnition {
-		bootstrapData = string(bootstrapJinjaScript)
+		bootstrapData = bootstrapJinjaScript
+	} else {
+		return ctrl.Result{}, errors.Wrapf(err,
+			"Error unsupported bootstrap format [%s]", bootstrapFormat)
 	}
 
 	// nothing is redacted in the cloud init script - please ensure no secrets are present

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -751,8 +751,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		// try to power on the VM
 		b64CloudInitScript := b64.StdEncoding.EncodeToString([]byte(cloudInit))
 		keyVals := map[string]string{
-			"guestinfo.userdata":          b64CloudInitScript,
-			"guestinfo.userdata.encoding": "base64",
+			"guestinfo.ignition.config":          b64CloudInitScript,
+			"guestinfo.ignition.config.encoding": "base64",
 			"disk.enableUUID":             "1",
 		}
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -1041,7 +1041,7 @@ func getNetworkConnection(connections *types.NetworkConnectionSection, ovdcNetwo
 		Network:                 ovdcNetwork,
 		NeedsCustomization:      false,
 		IsConnected:             true,
-		IPAddressAllocationMode: "DHCP",
+		IPAddressAllocationMode: "POOL",
 		NetworkAdapterType:      "VMXNET3",
 	}
 }

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -750,16 +750,13 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	// Collect OvdcNetwork to populate ignition metadata
-	OrgVdcNetwork, err := vdcManager.Vdc.GetOrgVdcNetworkByName(ovdcNetwork, true)
-	if err != nil {
-		return fmt.Errorf("unable to get ovdc network [%s]: [%v]", ovdcNetworkName, err)
-	}
+	OrgVdcNetwork, err := vdcManager.Vdc.GetOrgVdcNetworkByName(vcdCluster.Spec.OvdcNetwork, true)
 
 	// Convert netmask to CIDR notation for ignition
-	netmask := net.ParseIP(OrgVdcNetwork.Configuration.IpScopes.IpScope.Netmask)
-	netmaskCidr, _ := net.IPMask(ip.To4()).Size()
+	netmask := net.ParseIP(OrgVdcNetwork.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Netmask)
+	netmaskCidr, _ := net.IPMask(netmask.To4()).Size()
 	ignitionAddress := fmt.Sprint(machineAddress) + "/" + fmt.Sprint(netmaskCidr)
-
+	
 	if vmStatus != "POWERED_ON" {
 		// try to power on the VM
 		b64CloudInitScript := b64.StdEncoding.EncodeToString([]byte(cloudInit))
@@ -770,9 +767,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.ignition.config.data.encoding": "base64",
 			"guestinfo.ignition.vmname": vmName,
 			"guestinfo.ignition.machineaddress": ignitionAddress,
-			"guestinfo.ignition.gateway": OrgVdcNetwork.Configuration.IpScopes.IpScope.Gateway,
-			"guestinfo.ignition.dns1": OrgVdcNetwork.Configuration.IpScopes.IpScope.Dns1,
-			"guestinfo.ignition.dns2": OrgVdcNetwork.Configuration.IpScopes.IpScope.Dns2,
+			"guestinfo.ignition.gateway": OrgVdcNetwork.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Gateway,
+			"guestinfo.ignition.dns1": OrgVdcNetwork.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNS1,
+			"guestinfo.ignition.dns2": OrgVdcNetwork.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNS2,
 			"disk.enableUUID":             "1",
 		}
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -756,8 +756,6 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",
 			"disk.enableUUID":             "1",
-			"guestinfo.hostname": "testname",
-			"guestinfo.interface.ens192.dhcp": "yes",
 		}
 
 		for key, val := range keyVals {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -751,8 +751,10 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		// try to power on the VM
 		b64CloudInitScript := b64.StdEncoding.EncodeToString([]byte(cloudInit))
 		keyVals := map[string]string{
-			"guestinfo.ignition.config":          b64CloudInitScript,
-			"guestinfo.ignition.config.encoding": "base64",
+			"guestinfo.ignition.config.data":          b64CloudInitScript,
+			"guestinfo.ignition.config.data.encoding": "base64",
+			"guestinfo.userdata":          b64CloudInitScript,
+			"guestinfo.userdata.encoding": "base64",
 			"disk.enableUUID":             "1",
 		}
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -514,7 +514,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			vAppName, machine.Name, bootstrapJinjaScript)
 	}
 
-	cloudInit := string(mergedCloudInitBytes)
+	cloudInit := string(bootstrapJinjaScript)
 
 	// nothing is redacted in the cloud init script - please ensure no secrets are present
 	log.Info(fmt.Sprintf("Cloud init Script: [%s]", cloudInit))
@@ -749,7 +749,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	if vmStatus != "POWERED_ON" {
 		// try to power on the VM
-		b64CloudInitScript := b64.StdEncoding.EncodeToString(mergedCloudInitBytes)
+		b64CloudInitScript := b64.StdEncoding.EncodeToString(cloudInit)
 		keyVals := map[string]string{
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -757,7 +757,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.userdata.encoding": "base64",
 			"disk.enableUUID":             "1",
 			"guestinfo.hostname": "testname",
-			"guestinfo.interface.ens192.dhcp": "yes"
+			"guestinfo.interface.ens192.dhcp": "yes",
 		}
 
 		for key, val := range keyVals {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -756,6 +756,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",
 			"disk.enableUUID":             "1",
+			"guestinfo.hostname": "testname",
+			"guestinfo.interface.ens192.dhcp": "yes"
 		}
 
 		for key, val := range keyVals {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -755,6 +755,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.ignition.config.data.encoding": "base64",
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",
+			"guestinfo.vmname": vmName,
 			"disk.enableUUID":             "1",
 		}
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -831,7 +831,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.Error(err, "failed to remove VCDMachineCreationError from RDE", "rdeID", vcdCluster.Status.InfraId)
 	}
 
-	phases := postCustPhases
+	/* phases := postCustPhases
 	if useControlPlaneScript {
 		phases = append(phases, KubeadmInit)
 	} else {
@@ -868,7 +868,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 				vAppName, vm.VM.Name, phase)
 		}
 		log.Info(fmt.Sprintf("End: waiting for the bootstrapping phase [%s] to complete", phase))
-	}
+	} */
 
 	err = capvcdRdeManager.RdeManager.RemoveErrorByNameOrIdFromErrorSet(ctx, vcdsdk.ComponentCAPVCD, capisdk.VCDMachineScriptExecutionError, "", "")
 	if err != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -503,16 +503,16 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		cloudInitInput.ResizedControlPlane = isResizedControlPlane
 	}
 
-	mergedCloudInitBytes, err := MergeJinjaToCloudInitScript(cloudInitInput, bootstrapJinjaScript)
-	if err != nil {
-		err1 := capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDMachineScriptGenerationError, "", machine.Name, fmt.Sprintf("%v", err))
-		if err1 != nil {
-			log.Error(err1, "failed to add VCDMachineScriptGenerationError into RDE", "rdeID", vcdCluster.Status.InfraId)
-		}
-		return ctrl.Result{}, errors.Wrapf(err,
-			"Error merging bootstrap jinja script with the cloudInit script for [%s/%s] [%s]",
-			vAppName, machine.Name, bootstrapJinjaScript)
-	}
+	// mergedCloudInitBytes, err := MergeJinjaToCloudInitScript(cloudInitInput, bootstrapJinjaScript)
+	// if err != nil {
+	// 	err1 := capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDMachineScriptGenerationError, "", machine.Name, fmt.Sprintf("%v", err))
+	// 	if err1 != nil {
+	// 		log.Error(err1, "failed to add VCDMachineScriptGenerationError into RDE", "rdeID", vcdCluster.Status.InfraId)
+	// 	}
+	// 	return ctrl.Result{}, errors.Wrapf(err,
+	// 		"Error merging bootstrap jinja script with the cloudInit script for [%s/%s] [%s]",
+	// 		vAppName, machine.Name, bootstrapJinjaScript)
+	// }
 
 	cloudInit := string(bootstrapJinjaScript)
 
@@ -749,7 +749,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	if vmStatus != "POWERED_ON" {
 		// try to power on the VM
-		b64CloudInitScript := b64.StdEncoding.EncodeToString(cloudInit)
+		b64CloudInitScript := b64.StdEncoding.EncodeToString([]byte(cloudInit))
 		keyVals := map[string]string{
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -756,6 +756,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			"guestinfo.userdata":          b64CloudInitScript,
 			"guestinfo.userdata.encoding": "base64",
 			"disk.enableUUID":             "1",
+			"guestinfo.hostname": "testname",
+			"guestinfo.interface.ens192.dhcp": "yes",
 		}
 
 		for key, val := range keyVals {
@@ -1026,7 +1028,7 @@ func getNetworkConnection(connections *types.NetworkConnectionSection, ovdcNetwo
 		Network:                 ovdcNetwork,
 		NeedsCustomization:      false,
 		IsConnected:             true,
-		IPAddressAllocationMode: "POOL",
+		IPAddressAllocationMode: "DHCP",
 		NetworkAdapterType:      "VMXNET3",
 	}
 }

--- a/examples/flatcar-ignition.yaml
+++ b/examples/flatcar-ignition.yaml
@@ -86,4 +86,4 @@ ignition:
               [Service]
               # Make metadata environment variables available for pre-kubeadm commands.
               EnvironmentFile=/run/metadata/*
-{{- end -}}
+              

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -1,0 +1,361 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+  labels:
+    cni: antrea
+    ccm: external
+    csi: external
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the cluster
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: VCDCluster
+    name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: ${TARGET_NAMESPACE}
+type: Opaque
+data:
+  username: "${VCD_USERNAME_B64}" # username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  site: ${VCD_SITE} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
+  org: ${VCD_ORGANIZATION} # VCD organization name where the cluster should be deployed
+  ovdc: ${VCD_ORGANIZATION_VDC} # VCD virtual datacenter name where the cluster should be deployed
+  ovdcNetwork: ${VCD_ORGANIZATION_VDC_NETWORK} # VCD virtual datacenter network to be used by the cluster
+  useAsManagementCluster: false # intent to use the resultant CAPVCD cluster as a management cluster
+  userContext:
+    secretRef:
+      name: capi-user-credentials # name of the secret containing the credentials of the VCD persona creating the cluster
+      namespace: ${TARGET_NAMESPACE} # name of the secret containing the credentials of the VCD persona creating the cluster
+  rdeId: ${VCD_RDE_ID} # rdeId if it is already created. If empty, CAPVCD will create one for the cluster.
+  loadBalancerConfigSpec:
+    vipSubnet: ${VCD_VIP_CIDR} # Virtual IP CIDR for the external network
+  proxyConfigSpec:
+    httpProxy: ${HTTP_PROXY}
+    httpsProxy: ${HTTPS_PROXY}
+    noProxy: ${NO_PROXY}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the control plane VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes
+      sizingPolicy: ${VCD_CONTROL_PLANE_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter)
+      placementPolicy: ${VCD_CONTROL_PLANE_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_CONTROL_PLANE_STORAGE_PROFILE}" # Storage profile to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter)
+      diskSize: ${DISK_SIZE}
+      enableNvidiaGPU: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: coredns # image repository to pull the DNS image from
+        imageTag: ${DNS_VERSION}
+      etcd:
+        local:
+          imageRepository: quay.io/coreos/etcd # image repository to pull the etcd image from
+          imageTag: ${ETCD_VERSION}
+      imageRepository: bitnami # image repository to use for the rest of kubernetes images
+    users:
+      - name: root
+        sshAuthorizedKeys:
+          - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the control plane VMs in VCD
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |-
+          storage:
+            files:
+            - path: /opt/set-hostname
+              filesystem: root
+              mode: 0744
+              contents:
+                inline: |
+                  #!/bin/sh
+                  set -x
+                  echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                  hostname "${COREOS_CUSTOM_HOSTNAME}"
+                  echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                  echo "127.0.0.1   localhost" >>/etc/hosts
+                  echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+          systemd:
+            units:
+            - name: coreos-metadata.service
+              contents: |
+                [Unit]
+                Description=VMware metadata agent
+                After=nss-lookup.target
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                Type=oneshot
+                Restart=on-failure
+                RemainAfterExit=yes
+                Environment=OUTPUT=/run/metadata/coreos
+                ExecStart=/usr/bin/mkdir --parent /run/metadata
+                ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+            - name: set-hostname.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Set the hostname
+                Requires=coreos-metadata.service
+                After=coreos-metadata.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                EnvironmentFile=/run/metadata/coreos
+                ExecStart=/opt/set-hostname
+                [Install]
+                WantedBy=multi-user.target
+            - name: set-networkd-units.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Install the networkd unit files
+                Requires=coreos-metadata.service
+                After=set-hostname.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                ExecStart=/opt/set-networkd-units
+                [Install]
+                WantedBy=multi-user.target
+            - name: ethtool-segmentation.service
+              enabled: true
+              contents: |
+                [Unit]
+                After=network.target
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                [Install]
+                WantedBy=default.target
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=set-networkd-units.service
+                  [Service]
+                  # Make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: VCDMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
+  version: ${KUBERNETES_VERSION} # Kubernetes version to be used to create (or) upgrade the control plane nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-${WORKER_POOL_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the worker VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the worker nodes
+      sizingPolicy: ${VCD_WORKER_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter)
+      placementPolicy: ${VCD_WORKER_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_WORKER_STORAGE_PROFILE}" # Storage profile to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter)
+      diskSize: ${DISK_SIZE}
+      enableNvidiaGPU: false
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-${WORKER_POOL_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys:
+            - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the worker VMs in VCD
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cloud-provider: external
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |-
+            storage:
+              files:
+              - path: /opt/set-hostname
+                filesystem: root
+                mode: 0744
+                contents:
+                  inline: |
+                    #!/bin/sh
+                    set -x
+                    echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                    hostname "${COREOS_CUSTOM_HOSTNAME}"
+                    echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                    echo "127.0.0.1   localhost" >>/etc/hosts
+                    echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+            systemd:
+              units:
+              - name: coreos-metadata.service
+                contents: |
+                  [Unit]
+                  Description=VMware metadata agent
+                  After=nss-lookup.target
+                  After=network-online.target
+                  Wants=network-online.target
+                  [Service]
+                  Type=oneshot
+                  Restart=on-failure
+                  RemainAfterExit=yes
+                  Environment=OUTPUT=/run/metadata/coreos
+                  ExecStart=/usr/bin/mkdir --parent /run/metadata
+                  ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+              - name: set-hostname.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Set the hostname
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  EnvironmentFile=/run/metadata/coreos
+                  ExecStart=/opt/set-hostname
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: set-networkd-units.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Install the networkd unit files
+                  Requires=coreos-metadata.service
+                  After=set-hostname.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                  ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                  ExecStart=/opt/set-networkd-units
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: ethtool-segmentation.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  After=network.target
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                  [Install]
+                  WantedBy=default.target
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                    Requires=coreos-metadata.service
+                    After=set-networkd-units.service
+                    [Service]
+                    # Make metadata environment variables available for pre-kubeadm commands.
+                    EnvironmentFile=/run/metadata/*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-${WORKER_POOL_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME} # name of the Cluster object
+  replicas: ${WORKER_MACHINE_COUNT} # desired number of worker nodes for the cluster
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-${WORKER_POOL_NAME} # name of the KubeadmConfigTemplate object
+          namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
+      clusterName: ${CLUSTER_NAME} # name of the Cluster object
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: VCDMachineTemplate
+        name: ${CLUSTER_NAME}-${WORKER_POOL_NAME} # name of the VCDMachineTemplate object used to deploy worker nodes
+        namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
+      version: ${KUBERNETES_VERSION} # Kubernetes version to be used to create (or) upgrade the worker nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.

--- a/templates/cluster-template-v1.24.10-crs-ignition.yaml
+++ b/templates/cluster-template-v1.24.10-crs-ignition.yaml
@@ -1,0 +1,356 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+  labels:
+    cni: antrea
+    ccm: external
+    csi: external
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the clusterrdeId
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: VCDCluster
+    name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: ${TARGET_NAMESPACE}
+type: Opaque
+data:
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  site: ${VCD_SITE} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
+  org: ${VCD_ORGANIZATION} # VCD organization name where the cluster should be deployed
+  ovdc: ${VCD_ORGANIZATION_VDC} # VCD virtual datacenter name where the cluster should be deployed
+  ovdcNetwork: ${VCD_ORGANIZATION_VDC_NETWORK} # VCD virtual datacenter network to be used by the cluster
+  useAsManagementCluster: false # intent to use the resultant CAPVCD cluster as a management cluster; defaults to false
+  userContext:
+    secretRef:
+      name: capi-user-credentials
+      namespace: ${TARGET_NAMESPACE}
+  loadBalancerConfigSpec:
+    vipSubnet: "" # Virtual IP CIDR for the external network
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the control plane VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_CONTROL_PLANE_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_CONTROL_PLANE_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_CONTROL_PLANE_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size to use for the control plane machine, defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: coredns # image repository to pull the DNS image from
+        imageTag: 1.8.6
+      etcd:
+        local:
+          imageRepository: quay.io/coreos/etcd # image repository to pull the etcd image from
+          imageTag: v3.5.6
+      imageRepository: bitnami # image repository to use for the rest of kubernetes images
+    users:
+      - name: root
+        sshAuthorizedKeys:
+          - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the control plane VMs in VCD
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |-
+          storage:
+            files:
+            - path: /opt/set-hostname
+              filesystem: root
+              mode: 0744
+              contents:
+                inline: |
+                  #!/bin/sh
+                  set -x
+                  echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                  hostname "${COREOS_CUSTOM_HOSTNAME}"
+                  echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                  echo "127.0.0.1   localhost" >>/etc/hosts
+                  echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+          systemd:
+            units:
+            - name: coreos-metadata.service
+              contents: |
+                [Unit]
+                Description=VMware metadata agent
+                After=nss-lookup.target
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                Type=oneshot
+                Restart=on-failure
+                RemainAfterExit=yes
+                Environment=OUTPUT=/run/metadata/coreos
+                ExecStart=/usr/bin/mkdir --parent /run/metadata
+                ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+            - name: set-hostname.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Set the hostname
+                Requires=coreos-metadata.service
+                After=coreos-metadata.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                EnvironmentFile=/run/metadata/coreos
+                ExecStart=/opt/set-hostname
+                [Install]
+                WantedBy=multi-user.target
+            - name: set-networkd-units.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Install the networkd unit files
+                Requires=coreos-metadata.service
+                After=set-hostname.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                ExecStart=/opt/set-networkd-units
+                [Install]
+                WantedBy=multi-user.target
+            - name: ethtool-segmentation.service
+              enabled: true
+              contents: |
+                [Unit]
+                After=network.target
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                [Install]
+                WantedBy=default.target
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=set-networkd-units.service
+                  [Service]
+                  # Make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: VCDMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
+  version: v1.24.10 # Kubernetes version to be used to create (or) upgrade the control plane nodes.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the worker VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_WORKER_SIZING_POLICY} # Sizing policy to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_WORKER_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_WORKER_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size for the worker machine; defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys:
+            - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the worker VMs in VCD
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cloud-provider: external
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |-
+            storage:
+              files:
+              - path: /opt/set-hostname
+                filesystem: root
+                mode: 0744
+                contents:
+                  inline: |
+                    #!/bin/sh
+                    set -x
+                    echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                    hostname "${COREOS_CUSTOM_HOSTNAME}"
+                    echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                    echo "127.0.0.1   localhost" >>/etc/hosts
+                    echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+            systemd:
+              units:
+              - name: coreos-metadata.service
+                contents: |
+                  [Unit]
+                  Description=VMware metadata agent
+                  After=nss-lookup.target
+                  After=network-online.target
+                  Wants=network-online.target
+                  [Service]
+                  Type=oneshot
+                  Restart=on-failure
+                  RemainAfterExit=yes
+                  Environment=OUTPUT=/run/metadata/coreos
+                  ExecStart=/usr/bin/mkdir --parent /run/metadata
+                  ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+              - name: set-hostname.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Set the hostname
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  EnvironmentFile=/run/metadata/coreos
+                  ExecStart=/opt/set-hostname
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: set-networkd-units.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Install the networkd unit files
+                  Requires=coreos-metadata.service
+                  After=set-hostname.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                  ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                  ExecStart=/opt/set-networkd-units
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: ethtool-segmentation.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  After=network.target
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                  [Install]
+                  WantedBy=default.target
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                    Requires=coreos-metadata.service
+                    After=set-networkd-units.service
+                    [Service]
+                    # Make metadata environment variables available for pre-kubeadm commands.
+                    EnvironmentFile=/run/metadata/*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME} # name of the Cluster object
+  replicas: ${WORKER_MACHINE_COUNT} # desired number of worker nodes for the cluster
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0 # name of the KubeadmConfigTemplate object
+          namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
+      clusterName: ${CLUSTER_NAME} # name of the Cluster object
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: VCDMachineTemplate
+        name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
+        namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
+      version: v1.24.10 # Kubernetes version to be used to create (or) upgrade the worker nodes.

--- a/templates/cluster-template-v1.24.10-ignition.yaml
+++ b/templates/cluster-template-v1.24.10-ignition.yaml
@@ -1,0 +1,352 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the clusterrdeId
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: VCDCluster
+    name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: ${TARGET_NAMESPACE}
+type: Opaque
+data:
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  site: ${VCD_SITE} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
+  org: ${VCD_ORGANIZATION} # VCD organization name where the cluster should be deployed
+  ovdc: ${VCD_ORGANIZATION_VDC} # VCD virtual datacenter name where the cluster should be deployed
+  ovdcNetwork: ${VCD_ORGANIZATION_VDC_NETWORK} # VCD virtual datacenter network to be used by the cluster
+  useAsManagementCluster: false # intent to use the resultant CAPVCD cluster as a management cluster; defaults to false
+  userContext:
+    secretRef:
+      name: capi-user-credentials
+      namespace: ${TARGET_NAMESPACE}
+  loadBalancerConfigSpec:
+    vipSubnet: "" # Virtual IP CIDR for the external network
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the control plane VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_CONTROL_PLANE_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_CONTROL_PLANE_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_CONTROL_PLANE_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size to use for the control plane machine, defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: coredns # image repository to pull the DNS image from
+        imageTag: 1.8.6
+      etcd:
+        local:
+          imageRepository: quay.io/coreos/etcd # image repository to pull the etcd image from
+          imageTag: v3.5.6
+      imageRepository: bitnami # image repository to use for the rest of kubernetes images
+    users:
+      - name: root
+        sshAuthorizedKeys:
+          - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the control plane VMs in VCD
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |-
+          storage:
+            files:
+            - path: /opt/set-hostname
+              filesystem: root
+              mode: 0744
+              contents:
+                inline: |
+                  #!/bin/sh
+                  set -x
+                  echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                  hostname "${COREOS_CUSTOM_HOSTNAME}"
+                  echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                  echo "127.0.0.1   localhost" >>/etc/hosts
+                  echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+          systemd:
+            units:
+            - name: coreos-metadata.service
+              contents: |
+                [Unit]
+                Description=VMware metadata agent
+                After=nss-lookup.target
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                Type=oneshot
+                Restart=on-failure
+                RemainAfterExit=yes
+                Environment=OUTPUT=/run/metadata/coreos
+                ExecStart=/usr/bin/mkdir --parent /run/metadata
+                ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+            - name: set-hostname.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Set the hostname
+                Requires=coreos-metadata.service
+                After=coreos-metadata.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                EnvironmentFile=/run/metadata/coreos
+                ExecStart=/opt/set-hostname
+                [Install]
+                WantedBy=multi-user.target
+            - name: set-networkd-units.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Install the networkd unit files
+                Requires=coreos-metadata.service
+                After=set-hostname.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                ExecStart=/opt/set-networkd-units
+                [Install]
+                WantedBy=multi-user.target
+            - name: ethtool-segmentation.service
+              enabled: true
+              contents: |
+                [Unit]
+                After=network.target
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                [Install]
+                WantedBy=default.target
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=set-networkd-units.service
+                  [Service]
+                  # Make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: VCDMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
+  version: v1.24.10 # Kubernetes version to be used to create (or) upgrade the control plane nodes.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the worker VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_WORKER_SIZING_POLICY} # Sizing policy to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_WORKER_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_WORKER_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size for the worker machine; defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys:
+            - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the worker VMs in VCD
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cloud-provider: external
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |-
+            storage:
+              files:
+              - path: /opt/set-hostname
+                filesystem: root
+                mode: 0744
+                contents:
+                  inline: |
+                    #!/bin/sh
+                    set -x
+                    echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                    hostname "${COREOS_CUSTOM_HOSTNAME}"
+                    echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                    echo "127.0.0.1   localhost" >>/etc/hosts
+                    echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+            systemd:
+              units:
+              - name: coreos-metadata.service
+                contents: |
+                  [Unit]
+                  Description=VMware metadata agent
+                  After=nss-lookup.target
+                  After=network-online.target
+                  Wants=network-online.target
+                  [Service]
+                  Type=oneshot
+                  Restart=on-failure
+                  RemainAfterExit=yes
+                  Environment=OUTPUT=/run/metadata/coreos
+                  ExecStart=/usr/bin/mkdir --parent /run/metadata
+                  ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+              - name: set-hostname.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Set the hostname
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  EnvironmentFile=/run/metadata/coreos
+                  ExecStart=/opt/set-hostname
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: set-networkd-units.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Install the networkd unit files
+                  Requires=coreos-metadata.service
+                  After=set-hostname.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                  ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                  ExecStart=/opt/set-networkd-units
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: ethtool-segmentation.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  After=network.target
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                  [Install]
+                  WantedBy=default.target
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                    Requires=coreos-metadata.service
+                    After=set-networkd-units.service
+                    [Service]
+                    # Make metadata environment variables available for pre-kubeadm commands.
+                    EnvironmentFile=/run/metadata/*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME} # name of the Cluster object
+  replicas: ${WORKER_MACHINE_COUNT} # desired number of worker nodes for the cluster
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0 # name of the KubeadmConfigTemplate object
+          namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
+      clusterName: ${CLUSTER_NAME} # name of the Cluster object
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: VCDMachineTemplate
+        name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
+        namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
+      version: v1.24.10 # Kubernetes version to be used to create (or) upgrade the worker nodes.

--- a/templates/cluster-template-v1.25.7-crs-ignition.yaml
+++ b/templates/cluster-template-v1.25.7-crs-ignition.yaml
@@ -1,0 +1,356 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+  labels:
+    cni: antrea
+    ccm: external
+    csi: external
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the clusterrdeId
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: VCDCluster
+    name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: ${TARGET_NAMESPACE}
+type: Opaque
+data:
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  site: ${VCD_SITE} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
+  org: ${VCD_ORGANIZATION} # VCD organization name where the cluster should be deployed
+  ovdc: ${VCD_ORGANIZATION_VDC} # VCD virtual datacenter name where the cluster should be deployed
+  ovdcNetwork: ${VCD_ORGANIZATION_VDC_NETWORK} # VCD virtual datacenter network to be used by the cluster
+  useAsManagementCluster: false # intent to use the resultant CAPVCD cluster as a management cluster; defaults to false
+  userContext:
+    secretRef:
+      name: capi-user-credentials
+      namespace: ${TARGET_NAMESPACE}
+  loadBalancerConfigSpec:
+    vipSubnet: "" # Virtual IP CIDR for the external network
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the control plane VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_CONTROL_PLANE_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_CONTROL_PLANE_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_CONTROL_PLANE_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size to use for the control plane machine, defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: coredns # image repository to pull the DNS image from
+        imageTag: 1.9.3
+      etcd:
+        local:
+          imageRepository: quay.io/coreos/etcd # image repository to pull the etcd image from
+          imageTag: v3.5.6
+      imageRepository: bitnami # image repository to use for the rest of kubernetes images
+    users:
+      - name: root
+        sshAuthorizedKeys:
+          - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the control plane VMs in VCD
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |-
+          storage:
+            files:
+            - path: /opt/set-hostname
+              filesystem: root
+              mode: 0744
+              contents:
+                inline: |
+                  #!/bin/sh
+                  set -x
+                  echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                  hostname "${COREOS_CUSTOM_HOSTNAME}"
+                  echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                  echo "127.0.0.1   localhost" >>/etc/hosts
+                  echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+          systemd:
+            units:
+            - name: coreos-metadata.service
+              contents: |
+                [Unit]
+                Description=VMware metadata agent
+                After=nss-lookup.target
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                Type=oneshot
+                Restart=on-failure
+                RemainAfterExit=yes
+                Environment=OUTPUT=/run/metadata/coreos
+                ExecStart=/usr/bin/mkdir --parent /run/metadata
+                ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+            - name: set-hostname.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Set the hostname
+                Requires=coreos-metadata.service
+                After=coreos-metadata.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                EnvironmentFile=/run/metadata/coreos
+                ExecStart=/opt/set-hostname
+                [Install]
+                WantedBy=multi-user.target
+            - name: set-networkd-units.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Install the networkd unit files
+                Requires=coreos-metadata.service
+                After=set-hostname.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                ExecStart=/opt/set-networkd-units
+                [Install]
+                WantedBy=multi-user.target
+            - name: ethtool-segmentation.service
+              enabled: true
+              contents: |
+                [Unit]
+                After=network.target
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                [Install]
+                WantedBy=default.target
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=set-networkd-units.service
+                  [Service]
+                  # Make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: VCDMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
+  version: v1.25.7 # Kubernetes version to be used to create (or) upgrade the control plane nodes.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the worker VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_WORKER_SIZING_POLICY} # Sizing policy to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_WORKER_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_WORKER_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size for the worker machine; defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys:
+            - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the worker VMs in VCD
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cloud-provider: external
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |-
+            storage:
+              files:
+              - path: /opt/set-hostname
+                filesystem: root
+                mode: 0744
+                contents:
+                  inline: |
+                    #!/bin/sh
+                    set -x
+                    echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                    hostname "${COREOS_CUSTOM_HOSTNAME}"
+                    echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                    echo "127.0.0.1   localhost" >>/etc/hosts
+                    echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+            systemd:
+              units:
+              - name: coreos-metadata.service
+                contents: |
+                  [Unit]
+                  Description=VMware metadata agent
+                  After=nss-lookup.target
+                  After=network-online.target
+                  Wants=network-online.target
+                  [Service]
+                  Type=oneshot
+                  Restart=on-failure
+                  RemainAfterExit=yes
+                  Environment=OUTPUT=/run/metadata/coreos
+                  ExecStart=/usr/bin/mkdir --parent /run/metadata
+                  ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+              - name: set-hostname.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Set the hostname
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  EnvironmentFile=/run/metadata/coreos
+                  ExecStart=/opt/set-hostname
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: set-networkd-units.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Install the networkd unit files
+                  Requires=coreos-metadata.service
+                  After=set-hostname.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                  ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                  ExecStart=/opt/set-networkd-units
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: ethtool-segmentation.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  After=network.target
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                  [Install]
+                  WantedBy=default.target
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                    Requires=coreos-metadata.service
+                    After=set-networkd-units.service
+                    [Service]
+                    # Make metadata environment variables available for pre-kubeadm commands.
+                    EnvironmentFile=/run/metadata/*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME} # name of the Cluster object
+  replicas: ${WORKER_MACHINE_COUNT} # desired number of worker nodes for the cluster
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0 # name of the KubeadmConfigTemplate object
+          namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
+      clusterName: ${CLUSTER_NAME} # name of the Cluster object
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: VCDMachineTemplate
+        name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
+        namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
+      version: v1.25.7 # Kubernetes version to be used to create (or) upgrade the worker nodes.

--- a/templates/cluster-template-v1.25.7-ignition.yaml
+++ b/templates/cluster-template-v1.25.7-ignition.yaml
@@ -1,0 +1,352 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the clusterrdeId
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: VCDCluster
+    name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
+    namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: ${TARGET_NAMESPACE}
+type: Opaque
+data:
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  site: ${VCD_SITE} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
+  org: ${VCD_ORGANIZATION} # VCD organization name where the cluster should be deployed
+  ovdc: ${VCD_ORGANIZATION_VDC} # VCD virtual datacenter name where the cluster should be deployed
+  ovdcNetwork: ${VCD_ORGANIZATION_VDC_NETWORK} # VCD virtual datacenter network to be used by the cluster
+  useAsManagementCluster: false # intent to use the resultant CAPVCD cluster as a management cluster; defaults to false
+  userContext:
+    secretRef:
+      name: capi-user-credentials
+      namespace: ${TARGET_NAMESPACE}
+  loadBalancerConfigSpec:
+    vipSubnet: "" # Virtual IP CIDR for the external network
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the control plane VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_CONTROL_PLANE_SIZING_POLICY} # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_CONTROL_PLANE_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_CONTROL_PLANE_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size to use for the control plane machine, defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: coredns # image repository to pull the DNS image from
+        imageTag: 1.9.3
+      etcd:
+        local:
+          imageRepository: quay.io/coreos/etcd # image repository to pull the etcd image from
+          imageTag: v3.5.6
+      imageRepository: bitnami # image repository to use for the rest of kubernetes images
+    users:
+      - name: root
+        sshAuthorizedKeys:
+          - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the control plane VMs in VCD
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |-
+          storage:
+            files:
+            - path: /opt/set-hostname
+              filesystem: root
+              mode: 0744
+              contents:
+                inline: |
+                  #!/bin/sh
+                  set -x
+                  echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                  hostname "${COREOS_CUSTOM_HOSTNAME}"
+                  echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                  echo "127.0.0.1   localhost" >>/etc/hosts
+                  echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+          systemd:
+            units:
+            - name: coreos-metadata.service
+              contents: |
+                [Unit]
+                Description=VMware metadata agent
+                After=nss-lookup.target
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                Type=oneshot
+                Restart=on-failure
+                RemainAfterExit=yes
+                Environment=OUTPUT=/run/metadata/coreos
+                ExecStart=/usr/bin/mkdir --parent /run/metadata
+                ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+            - name: set-hostname.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Set the hostname
+                Requires=coreos-metadata.service
+                After=coreos-metadata.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                EnvironmentFile=/run/metadata/coreos
+                ExecStart=/opt/set-hostname
+                [Install]
+                WantedBy=multi-user.target
+            - name: set-networkd-units.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Install the networkd unit files
+                Requires=coreos-metadata.service
+                After=set-hostname.service
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                ExecStart=/opt/set-networkd-units
+                [Install]
+                WantedBy=multi-user.target
+            - name: ethtool-segmentation.service
+              enabled: true
+              contents: |
+                [Unit]
+                After=network.target
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                [Install]
+                WantedBy=default.target
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=set-networkd-units.service
+                  [Service]
+                  # Make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cloud-provider: external
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: VCDMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
+  version: v1.25.7 # Kubernetes version to be used to create (or) upgrade the control plane nodes.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VCDMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      catalog: ${VCD_CATALOG} # Catalog hosting the TKGm template, which will be used to deploy the worker VMs
+      template: ${VCD_TEMPLATE_NAME} # Name of the template to be used to create (or) upgrade the control plane nodes (this template must be pre-suploaded to the catalog in VCD)
+      sizingPolicy: ${VCD_WORKER_SIZING_POLICY} # Sizing policy to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+      placementPolicy: ${VCD_WORKER_PLACEMENT_POLICY} # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
+      storageProfile: "${VCD_WORKER_STORAGE_PROFILE}" # Storage profile for control plane machine if any
+      diskSize: ${DISK_SIZE} # Disk size for the worker machine; defaults to 20Gi
+      enableNvidiaGPU: false
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys:
+            - "${SSH_PUBLIC_KEY}" # ssh public key to log in to the worker VMs in VCD
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cloud-provider: external
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |-
+            storage:
+              files:
+              - path: /opt/set-hostname
+                filesystem: root
+                mode: 0744
+                contents:
+                  inline: |
+                    #!/bin/sh
+                    set -x
+                    echo "${COREOS_CUSTOM_HOSTNAME}" > /etc/hostname
+                    hostname "${COREOS_CUSTOM_HOSTNAME}"
+                    echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+                    echo "127.0.0.1   localhost" >>/etc/hosts
+                    echo "127.0.0.1   ${COREOS_CUSTOM_HOSTNAME}" >>/etc/hosts
+            systemd:
+              units:
+              - name: coreos-metadata.service
+                contents: |
+                  [Unit]
+                  Description=VMware metadata agent
+                  After=nss-lookup.target
+                  After=network-online.target
+                  Wants=network-online.target
+                  [Service]
+                  Type=oneshot
+                  Restart=on-failure
+                  RemainAfterExit=yes
+                  Environment=OUTPUT=/run/metadata/coreos
+                  ExecStart=/usr/bin/mkdir --parent /run/metadata
+                  ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.vmname")" > ${OUTPUT}'
+              - name: set-hostname.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Set the hostname
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  EnvironmentFile=/run/metadata/coreos
+                  ExecStart=/opt/set-hostname
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: set-networkd-units.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=Install the networkd unit files
+                  Requires=coreos-metadata.service
+                  After=set-hostname.service
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/bin/bash -cv 'echo "$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+                  ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
+                  ExecStart=/opt/set-networkd-units
+                  [Install]
+                  WantedBy=multi-user.target
+              - name: ethtool-segmentation.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  After=network.target
+                  [Service]
+                  Type=oneshot
+                  RemainAfterExit=yes
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+                  ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+                  [Install]
+                  WantedBy=default.target
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                    Requires=coreos-metadata.service
+                    After=set-networkd-units.service
+                    [Service]
+                    # Make metadata environment variables available for pre-kubeadm commands.
+                    EnvironmentFile=/run/metadata/*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME} # name of the Cluster object
+  replicas: ${WORKER_MACHINE_COUNT} # desired number of worker nodes for the cluster
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0 # name of the KubeadmConfigTemplate object
+          namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
+      clusterName: ${CLUSTER_NAME} # name of the Cluster object
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: VCDMachineTemplate
+        name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
+        namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
+      version: v1.25.7 # Kubernetes version to be used to create (or) upgrade the worker nodes.

--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -48,6 +48,7 @@ VCD_RDE_ID: "urn:vcloud:entity:vmware:capvcdCluster:UUID"
 VCD_VIP_CIDR: ""
 
 # Kubernetes cluster properties
+# When using the "ignition" flavor, do not append "vmware" strings to KUBERNETES_VERSION, ETCD_VERSION and DNS_VERSION as it will be pulling from public registries
 CLUSTER_NAME: "myCluster"
 TARGET_NAMESPACE: default
 CONTROL_PLANE_MACHINE_COUNT: 1

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
@@ -662,7 +662,7 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
 								Network:                 vapp.VApp.NetworkConfigSection.NetworkNames()[0],
 								NeedsCustomization:      false,
 								IsConnected:             true,
-								IPAddressAllocationMode: "DHCP",
+								IPAddressAllocationMode: "POOL",
 								NetworkAdapterType:      "VMXNET3",
 							},
 						},

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
@@ -662,7 +662,7 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
 								Network:                 vapp.VApp.NetworkConfigSection.NetworkNames()[0],
 								NeedsCustomization:      false,
 								IsConnected:             true,
-								IPAddressAllocationMode: "POOL",
+								IPAddressAllocationMode: "DHCP",
 								NetworkAdapterType:      "VMXNET3",
 							},
 						},


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

Adds support for Flatcar and maintains support for Ubuntu:

**For Flatcar**

- Set `providerSpecific.vmBootstrapFormat: ignition`
- Set `kubernetesVersion: v1.xx.yy` (without `+vmware.1`)
- Set `controlPlane.image.repository: giantswarm`

**For Ubuntu (default)**

- Set `providerSpecific.vmBootstrapFormat: cloud-config`
- Set `kubernetesVersion: v1.xx.yy+vmware.1`
- Set `controlPlane.image.repository: projects.registry.vmware.com/tkg`

Requires a supported version of the cluster chart: https://github.com/giantswarm/cluster-cloud-director/pull/225

Tests done listed in cluster chart PR ☝️ 

What it does:

1. A new `providerSpecific.vmBootstrapFormat` values field is introduced to support both `cloud-config` and `ignition`. At the moment cloud-init is still default.
2. Set 2 new metadata: `guestinfo.ignition.vmname` which contains the VM name to set hostname and `guestinfo.ignition.network` that loops through each NIC to write a bash script that creates the networkd unit files. Primary NIC also contains DNS info and GW. At the end the script restart networkd.
3. In the Ignition file, a `set-networkd-units` systemd unit stores the contents of `guestinfo.ignition.network` to `/opt/set-networkd-units` and runs it.
4. Each networkd unit file is named after the VCD network it is connected to and the NIC is matched through MACAddress. Example 👇 

```
ls /etc/systemd/network
GS-ISOLATED.network  test-network-flatcar.network

cat /etc/systemd/network/GS-ISOLATED.network
[Match]
MACAddress=00:50:56:01:0b:74
[Network]
Address=10.205.105.28/24
Gateway=10.205.105.1
DNS=10.205.105.253
```