### PR TITLE
gzip + base64 encode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: ubuntu-2204:default
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2204:default
+      image: ubuntu-2204:2024.05.1
     steps:
       - checkout
       - run:

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -474,7 +474,7 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 			// GZip then Base64 encode bootstrap data
 			gzipb64encodedData, err := gzipAndBase64Encode([]byte(b64BootstrapData))
 			if err != nil {
-				log.Fatalf("Error: %v", err)
+				log.Error(err, "Failed to gzip and base64 encode data")
 			}
 
 			keyVals = map[string]string{
@@ -615,7 +615,7 @@ func gzipAndBase64Encode(data []byte) (string, error) {
 	}
 
 	// Encode the compressed data to Base64
-	gzipb64Encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	gzipb64Encoded := b64.StdEncoding.EncodeToString(buf.Bytes())
 
 	return gzipb64Encoded, nil
 }

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -479,7 +479,7 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 
 			keyVals = map[string]string{
 				"guestinfo.ignition.config.data":          gzipb64encodedData,
-				"guestinfo.ignition.config.data.encoding": "gzip+base64",
+				"guestinfo.ignition.config.data.encoding": "gz+base64",
 				"guestinfo.ignition.vmname":               vmName,
 				"disk.enableUUID":                         "1",
 				"guestinfo.ignition.network":              networkMetadata,

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -472,7 +472,7 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 			}
 
 			// GZip then Base64 encode bootstrap data
-			gzipb64encodedData, err := gzipAndBase64Encode([]byte(b64BootstrapData))
+			gzipb64encodedData, err := gzipAndBase64Encode([]byte(bootstrapData))
 			if err != nil {
 				log.Error(err, "Failed to gzip and base64 encode data")
 			}

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -474,7 +474,7 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 			// GZip then Base64 encode bootstrap data
 			gzipb64encodedData, err := gzipAndBase64Encode([]byte(bootstrapData))
 			if err != nil {
-				log.Error(err, "Failed to gzip and base64 encode data")
+				return errors.Wrapf(err, "Failed to gzip and base64 encode bootstrap data for ignition [%s/%s]", vcdCluster.Name, vm.VM.Name)
 			}
 
 			keyVals = map[string]string{

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"compress/gzip"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
@@ -469,13 +470,16 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 
 				return errors.Wrapf(err, "Error while generating network initialization script for ignition [%s/%s]", vcdCluster.Name, vm.VM.Name)
 			}
-			maxSize := 50 * 1024
-			if len(b64BootstrapData) > maxSize {
-				b64BootstrapData = b64BootstrapData[:maxSize]
+
+			// GZip then Base64 encode bootstrap data
+			gzipb64encodedData, err := gzipAndBase64Encode(b64BootstrapData)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
 			}
+
 			keyVals = map[string]string{
-				"guestinfo.ignition.config.data":          b64BootstrapData,
-				"guestinfo.ignition.config.data.encoding": "base64",
+				"guestinfo.ignition.config.data":          gzipb64encodedData,
+				"guestinfo.ignition.config.data.encoding": "gzip+base64",
 				"guestinfo.ignition.vmname":               vmName,
 				"disk.enableUUID":                         "1",
 				"guestinfo.ignition.network":              networkMetadata,
@@ -590,6 +594,30 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 		log.Error(err, "failed to remove VCDMachineCreationError from RDE", "rdeID", vcdCluster.Status.InfraId)
 	}
 	return nil
+}
+
+func gzipAndBase64Encode(data []byte) (string, error) {
+	// Create a buffer to hold the compressed data
+	var buf bytes.Buffer
+
+	// Create a new gzip writer that writes to the buffer
+	gzipWriter := gzip.NewWriter(&buf)
+
+	// Write the original data to the gzip writer
+	_, err := gzipWriter.Write(data)
+	if err != nil {
+		return "", err
+	}
+
+	// Close the gzip writer to flush and complete the compression
+	if err := gzipWriter.Close(); err != nil {
+		return "", err
+	}
+
+	// Encode the compressed data to Base64
+	gzipb64Encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+
+	return gzipb64Encoded, nil
 }
 
 // getOVDCDetailsForMachine gets OVDC name and OVDC network name for the machine.

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -472,7 +472,7 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 			}
 
 			// GZip then Base64 encode bootstrap data
-			gzipb64encodedData, err := gzipAndBase64Encode(b64BootstrapData)
+			gzipb64encodedData, err := gzipAndBase64Encode([]byte(b64BootstrapData))
 			if err != nil {
 				log.Fatalf("Error: %v", err)
 			}

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -469,6 +469,10 @@ func (r *VCDMachineReconciler) reconcileVMBootstrap(ctx context.Context, vcdClie
 
 				return errors.Wrapf(err, "Error while generating network initialization script for ignition [%s/%s]", vcdCluster.Name, vm.VM.Name)
 			}
+			maxSize := 50 * 1024
+			if len(b64BootstrapData) > maxSize {
+				b64BootstrapData = b64BootstrapData[:maxSize]
+			}
 			keyVals = map[string]string{
 				"guestinfo.ignition.config.data":          b64BootstrapData,
 				"guestinfo.ignition.config.data.encoding": "base64",


### PR DESCRIPTION
When using large bootstrapdata, the update metadata tasks fail because there is an (undocumented) 64KB limit on VM advanced fields in VCD. 

This PR makes use of the `gzip+base64` encoding instead of `base64` supported by [Flatcar](https://www.flatcar.org/docs/latest/installing/cloud/vmware/#defining-the-ignition-config-or-coreos-cloudinit-cloud-config-in-guestinfo). Compressing the data before base64 allows to stay under that limit.
